### PR TITLE
Automatically build in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   miningbots-frontend-server:
     image: miningbots-frontend-server
+    build: .
     container_name: miningbots-frontend-server
     ports:
       - "80:80"


### PR DESCRIPTION
Automatically build the Apache container on `compose up`. This allows us to use the full capability of docker compose.