### PR TITLE
Show observer team names and win progress

### DIFF
--- a/game.js
+++ b/game.js
@@ -578,6 +578,18 @@ function drawGame(hostname, port) {
             //Possibly add more colours for >2 players too
             const colors = ['blue', 'red', 'green', 'yellow', 'purple', 'orange', 'pink'];
 
+            function ensurePlayer(playerId) {
+                if (!players.hasOwnProperty(playerId)) {
+                    players[playerId] = Object.keys(players).length;
+                    let sidebar=document.createElement("div");
+                    sidebar.classList.add("sidebar");
+                    sidebar.id="bot-sidebar-"+(Object.keys(players).length);
+                    document.getElementById("bot-info-megacontainer").appendChild(sidebar);
+                    sidebars.push(sidebar);
+                }
+                return players[playerId];
+            }
+
             function getPlayerLabel(playerId) {
                 return playerNames[playerId] || `Player ${playerId}`;
             }
@@ -707,15 +719,7 @@ function drawGame(hostname, port) {
             //Updates the bot's position and its job?
             function updateBot(botUpdate, playerId) {
                 const effectivePlayerId = botUpdate.player_id ?? playerId;
-                if (!players.hasOwnProperty(effectivePlayerId)) {
-                    players[effectivePlayerId] = Object.keys(players).length;
-                    let sidebar=document.createElement("div");
-                    sidebar.classList.add("sidebar");
-                    sidebar.id="bot-sidebar-"+(Object.keys(players).length);
-                    document.getElementById("bot-info-megacontainer").appendChild(sidebar);
-                    sidebars.push(sidebar);
-                }
-                const playerIndex = players[effectivePlayerId];
+                const playerIndex = ensurePlayer(effectivePlayerId);
 
                 const { id, position, variant, current_energy, current_job_id, cargo } = botUpdate;
                 if (botMap.has(id)) {
@@ -815,7 +819,8 @@ function drawGame(hostname, port) {
             }
 
             //Display a dialog box in the middle of the screen indicating the winner
-            function showWinner(playerId) {
+            async function showWinner(playerId) {
+                await ensurePlayerName(playerId);
                 let text = `<h1>${escapeHTML(getPlayerLabel(playerId))} Won!</h1>`;
                 DialogUtilities.showDialog(text,"We have a winner!");
             }
@@ -832,9 +837,7 @@ function drawGame(hostname, port) {
             }
             //shows a row for each player showing each bot and their data
             async function updateUI(player_id) {
-                if (!players.hasOwnProperty(player_id)) {
-                    players[player_id] = Object.keys(players).length;
-                }
+                const playerIndex = ensurePlayer(player_id);
 
                 console.log('Players object:', players);
                 console.log('Current player ID:', player_id);
@@ -842,7 +845,6 @@ function drawGame(hostname, port) {
 
                 await ensurePlayerName(player_id);
 
-                const playerIndex = players[player_id];
                 console.log('playerIndex:', playerIndex);
 
                 const sidebar = sidebars[playerIndex];
@@ -854,11 +856,10 @@ function drawGame(hostname, port) {
 
                 const header = document.createElement('div');
                 header.classList.add('player-header');
-                header.style.borderColor = color;
+                header.style.color = color;
 
                 const playerName = document.createElement('h4');
                 playerName.textContent = getPlayerLabel(player_id);
-                playerName.style.color = color;
                 header.appendChild(playerName);
 
                 const playerIdText = document.createElement('span');

--- a/game.js
+++ b/game.js
@@ -16,7 +16,6 @@ const server = CookieUtilities.getCookie("lastServer");
 // var port = 443;
 var hostname, port;
 // if (server !== null) hostname = server;
-var gameId;
 
 const CONFIG_=SettingsManager.read_settings_cookie();
 const GameUnvailableError = class extends Error {
@@ -321,6 +320,7 @@ function drawGame(hostname, port) {
         //Map config taken from server data
         .then(async result => {
             let map_config = await result.map_config;
+            const matchGameId = result.game_id;
             console.log('map_config:', map_config);
             // rendring information
 
@@ -516,7 +516,7 @@ function drawGame(hostname, port) {
 
             ws.onopen = function () {
                 console.log('Connected to WebSocket server');
-                const subscribeRequest = JSON.stringify({ game_id: result.game_id, observer_key: CONFIG_.observer_key, observer_name: 'Observer' });
+                const subscribeRequest = JSON.stringify({ game_id: matchGameId, observer_key: CONFIG_.observer_key, observer_name: 'Observer' });
                 ws.send(subscribeRequest);
             };
 
@@ -578,17 +578,144 @@ function drawGame(hostname, port) {
             //Possibly add more colours for >2 players too
             const colors = ['blue', 'red', 'green', 'yellow', 'purple', 'orange', 'pink'];
 
+            function getPlayerLabel(playerId) {
+                return playerNames[playerId] || `Player ${playerId}`;
+            }
+
+            function escapeHTML(value) {
+                return String(value).replace(/[&<>"']/g, char => ({
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#39;'
+                })[char]);
+            }
+
+            async function ensurePlayerName(playerId) {
+                if (playerNames[playerId]) {
+                    return playerNames[playerId];
+                }
+
+                const playerInfo = await fetchPlayerNames(matchGameId, [playerId]);
+                if (Array.isArray(playerInfo) && playerInfo.length > 0 && playerInfo[0].name) {
+                    playerNames[playerId] = playerInfo[0].name;
+                }
+                return getPlayerLabel(playerId);
+            }
+
+            function cargoAmount(cargo, resourceId) {
+                const chunk = cargo.find(item => item.id === resourceId);
+                return chunk ? chunk.amount : 0;
+            }
+
+            function progressForFactory(factoryCargo) {
+                const totalRequired = map_config.win_condition.reduce((sum, chunk) => sum + chunk.amount, 0);
+                if (totalRequired <= 0) {
+                    return { percent: 0, current: 0, total: 0, chunks: [] };
+                }
+
+                const chunks = map_config.win_condition.map(chunk => {
+                    const amount = cargoAmount(factoryCargo, chunk.id);
+                    return {
+                        id: chunk.id,
+                        amount,
+                        required: chunk.amount,
+                        complete: amount >= chunk.amount
+                    };
+                });
+                const current = chunks.reduce((sum, chunk) => sum + Math.min(chunk.amount, chunk.required), 0);
+
+                return {
+                    percent: Math.floor((current / totalRequired) * 100),
+                    current,
+                    total: totalRequired,
+                    chunks
+                };
+            }
+
+            function bestWinProgress(playerIndex) {
+                let best = null;
+                for (const [id, [_position, variant, _current_energy, _job, cargo, botPlayerIndex]] of botMap.entries()) {
+                    if (playerIndex !== botPlayerIndex || variant !== 'kFactoryBot') {
+                        continue;
+                    }
+                    const progress = progressForFactory(cargo);
+                    if (best === null || progress.percent > best.percent) {
+                        best = { botId: id, ...progress };
+                    }
+                }
+                return best || { botId: null, percent: 0, current: 0, total: 0, chunks: [] };
+            }
+
+            function appendWinProgress(parent, playerIndex) {
+                const progress = bestWinProgress(playerIndex);
+                const progressBox = document.createElement('div');
+                progressBox.classList.add('win-progress');
+
+                const heading = document.createElement('div');
+                heading.classList.add('win-progress-heading');
+
+                const title = document.createElement('span');
+                title.textContent = progress.botId === null ? 'Win progress' : `Factory ${progress.botId}`;
+                heading.appendChild(title);
+
+                const percent = document.createElement('span');
+                percent.textContent = `${progress.percent}%`;
+                heading.appendChild(percent);
+                progressBox.appendChild(heading);
+
+                const bar = document.createElement('div');
+                bar.classList.add('win-progress-bar');
+                const fill = document.createElement('div');
+                fill.classList.add('win-progress-fill');
+                fill.style.width = `${Math.min(progress.percent, 100)}%`;
+                bar.appendChild(fill);
+                progressBox.appendChild(bar);
+
+                const quotaGrid = document.createElement('div');
+                quotaGrid.classList.add('win-quota-grid');
+                progress.chunks.forEach(chunk => {
+                    const resource = map_config.resource_configs[chunk.id];
+                    const row = document.createElement('div');
+                    row.classList.add('win-quota-row');
+                    if (chunk.complete) {
+                        row.classList.add('complete');
+                    }
+
+                    const label = document.createElement('span');
+                    label.textContent = resource ? resource.name : `Resource ${chunk.id}`;
+                    row.appendChild(label);
+
+                    const amount = document.createElement('span');
+                    amount.textContent = `${chunk.amount}/${chunk.required}`;
+                    row.appendChild(amount);
+                    quotaGrid.appendChild(row);
+                });
+
+                if (progress.chunks.length === 0) {
+                    const row = document.createElement('div');
+                    row.classList.add('win-quota-row');
+                    row.textContent = 'No win condition configured';
+                    quotaGrid.appendChild(row);
+                }
+
+                progressBox.appendChild(quotaGrid);
+                parent.appendChild(progressBox);
+            }
+
             //Updates the bot's position and its job?
             function updateBot(botUpdate, playerId) {
-                if (!players.hasOwnProperty(playerId)) {
-                    players[playerId] = Object.keys(players).length;
+                const effectivePlayerId = botUpdate.player_id ?? playerId;
+                if (!players.hasOwnProperty(effectivePlayerId)) {
+                    players[effectivePlayerId] = Object.keys(players).length;
                     let sidebar=document.createElement("div");
                     sidebar.classList.add("sidebar");
                     sidebar.id="bot-sidebar-"+(Object.keys(players).length);
                     document.getElementById("bot-info-megacontainer").appendChild(sidebar);
                     sidebars.push(sidebar);
                 }
-                const playerIndex = players[playerId];
+                const playerIndex = players[effectivePlayerId];
 
                 const { id, position, variant, current_energy, current_job_id, cargo } = botUpdate;
                 if (botMap.has(id)) {
@@ -689,7 +816,7 @@ function drawGame(hostname, port) {
 
             //Display a dialog box in the middle of the screen indicating the winner
             function showWinner(playerId) {
-                let text = `<h1>Player ${playerId} Won!</h1>`;
+                let text = `<h1>${escapeHTML(getPlayerLabel(playerId))} Won!</h1>`;
                 DialogUtilities.showDialog(text,"We have a winner!");
             }
 
@@ -705,7 +832,7 @@ function drawGame(hostname, port) {
             }
             //shows a row for each player showing each bot and their data
             async function updateUI(player_id) {
-                if (!players.hasOwnProperty(player_id) && Object.keys(players).length < 2) {
+                if (!players.hasOwnProperty(player_id)) {
                     players[player_id] = Object.keys(players).length;
                 }
 
@@ -713,10 +840,7 @@ function drawGame(hostname, port) {
                 console.log('Current player ID:', player_id);
 
 
-                // Player names code:
-                let playerInfo = await fetchPlayerNames(gameId, [player_id]);
-                console.log(playerInfo);
-                // var name = playerInfo[0].name;
+                await ensurePlayerName(player_id);
 
                 const playerIndex = players[player_id];
                 console.log('playerIndex:', playerIndex);
@@ -728,23 +852,30 @@ function drawGame(hostname, port) {
 
                 sidebar.innerHTML = ''; // Clear the existing sidebar content
 
-                const header = document.createElement('h4');
-                header.textContent = `Player: ${player_id}`;
-                header.style.color = color;
-                header.style.fontSize = "0.8vw";
-                header.style.margin = "0vw";
-                header.style.padding = "0.05vw";
+                const header = document.createElement('div');
+                header.classList.add('player-header');
+                header.style.borderColor = color;
+
+                const playerName = document.createElement('h4');
+                playerName.textContent = getPlayerLabel(player_id);
+                playerName.style.color = color;
+                header.appendChild(playerName);
+
+                const playerIdText = document.createElement('span');
+                playerIdText.textContent = `ID ${player_id}`;
+                header.appendChild(playerIdText);
                 sidebar.appendChild(header);
 
+                appendWinProgress(sidebar, playerIndex);
+
                 const botBox = document.createElement('div');
-                botBox.style = "display: flex; gap: 0vw; padding: 0vw, margin: 0.1vw; height: 100%; width: 100%; overflow-y: auto";
+                botBox.classList.add('bot-box');
                 sidebar.appendChild(botBox);
                 for (const [id, [position, variant, current_energy, job, cargo, botPlayerIndex]] of botMap.entries()) {
                     if (playerIndex == botPlayerIndex) { //THIS MIGHT NOT WORK
                         const botDiv = document.createElement('div');
                         console.log('cargo: ', cargo);
                         botDiv.classList.add('bot-info');
-                        botDiv.style = "width: 14%, height: 24%";
                         botDiv.innerHTML = `
                 <h4 style="margin: 2px 0; padding: 0;"><b>${NameMaps.mapName("variantMap", variant)}</b> ${id}</h4>
                 <hr style="margin: 2px 0;">

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,8 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  background-color: #f8fafc;
+  color: #172033;
 }
 
 body::backdrop{
@@ -17,6 +19,7 @@ body::backdrop{
   width: auto;
   position: relative;
   right: 0;
+  background-color: #e5e7eb;
 }
 
 .h4 {
@@ -24,39 +27,119 @@ body::backdrop{
 }
 
 .sidebar {
-  /* This allows the bot-info DIVs to be aligned horizontally */
   display: block;
-  /* flex-wrap: nowrap; */
-  /* flex-direction: row; */
-
-  /* In theory, the automatic width would adapt based on the size of the game canvas */
-  /* And auto height should help with > 1 player -> hopefully evenly distributed height */
   width: auto;
-  height: 20%;
+  min-height: 20%;
 
-  background-color: #f1f1f1;
-  padding: 0.1vw;
+  background-color: #f8fafc;
+  padding: 6px;
   overflow-x: auto;
-  overflow-y:hidden;
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  overflow-y: hidden;
+  border-bottom: 1px solid #d1d5db;
+  box-shadow: -2px 0 5px rgba(15, 23, 42, 0.08);
+}
+
+.player-header {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 6px;
+  padding-left: 6px;
+  border-left: 4px solid currentColor;
+}
+
+.player-header h4 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.player-header span {
+  color: #64748b;
+  font-size: 11px;
+}
+
+.win-progress {
+  margin-bottom: 6px;
+  padding: 6px;
+  background-color: #fff;
+  border: 1px solid #dbe2ea;
+  border-radius: 6px;
+}
+
+.win-progress-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: #334155;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.win-progress-bar {
+  height: 7px;
+  margin-top: 5px;
+  overflow: hidden;
+  background-color: #e2e8f0;
+  border-radius: 999px;
+}
+
+.win-progress-fill {
+  height: 100%;
+  background-color: #16a34a;
+  border-radius: inherit;
+}
+
+.win-quota-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(86px, 1fr));
+  gap: 4px 8px;
+  margin-top: 6px;
+}
+
+.win-quota-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+  color: #475569;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.win-quota-row.complete {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.bot-box {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .bot-info {
   margin: 2px;
-  padding: 2px;
-  border: 1px solid #ccc;
+  padding: 5px;
+  min-width: 112px;
+  border: 1px solid #dbe2ea;
+  border-radius: 6px;
   background-color: #fff;
 }
 
 .bot-info h4 {
   margin: 0;
   padding: 0;
-  font-size: 0.55vw;
+  color: #172033;
+  font-size: 11px;
 }
 
 .bot-info p {
-  margin: 5px 0;
-  font-size: 0.55vw;
+  margin: 4px 0;
+  color: #334155;
+  font-size: 11px;
 }
 
 #navbar-peek-triggerbox:hover + .navbar {


### PR DESCRIPTION
## Summary
- show observer team names by fetching /players with the active game id
- add win-condition progress for each team based on the best single factory bot cargo
- lightly polish the observer sidebar while preserving horizontal bot-card scrolling

## Validation
- node --check game.js
- git diff --check main..HEAD
- local static server smoke check with curl
- review-cycle skill: first pass found only borderline edge cases, follow-up commit fixed them, final pass reported no substantive findings