### PR TITLE
Add title

### DIFF
--- a/scripts/ui/server_text.js
+++ b/scripts/ui/server_text.js
@@ -1,6 +1,6 @@
 function setServerName(name){
     let link=document.getElementById("serverMenuButton")
-    link.textContent=`Server: ${name}`;
+    link.title=link.textContent=`Server: ${name}`; // should become tooltip too to avoid clipping text
     link.ariaLabel="Server";
     link.ariaDescription=name;
 }


### PR DESCRIPTION
The new Tailwind-based UI clipped off the server name text. We use the JS `title` attribute to allow it to be clearly visible.